### PR TITLE
Fix ordering doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Documentation is on [parts folder](https://github.com/teambox/api-v3-docs/tree/m
 1. Install <a href="http://nodejs.org/" target="_blank">node</a> `brew install node`.
 2. Install <a href="http://gulpjs.com/" target="_blank">Gulp</a> `npm install --global gulp`
 3. Fork this repo
-4. Once forked and cloned go to root folder and run: `npm install`
+4. Once forked and cloned go to root folder and run: `make render`
 5. Now run `gulp`
 6. Go to your browser to `http://localhost:8080`
 7. Done
@@ -19,9 +19,9 @@ Documentation is on [parts folder](https://github.com/teambox/api-v3-docs/tree/m
 ## Compile to production
 If you want to generate the production version of this docs you can do
 it with this command:
-```
-  gulp build-production --env production
 
+```shell
+gulp build-production --env production
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Documentation is on [parts folder](https://github.com/teambox/api-v3-docs/tree/m
 If you want to generate the production version of this docs you can do
 it with this command:
 
-```shell
+```sh
 gulp build-production --env production
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ options = {
  * @return {String}
  */
 function getEnviroment () {
-  args = getEnviromentVariables()
+  var args = getEnviromentVariables()
     , available_envs = ['development', 'production'];
 
   if (args.env && _.indexOf(available_envs, args.env) != -1 ) {

--- a/parts/activities.md
+++ b/parts/activities.md
@@ -27,7 +27,7 @@ Returns a JSON list of activities to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... The id of the organization to which the element belongs.

--- a/parts/comments.md
+++ b/parts/comments.md
@@ -77,7 +77,7 @@ Returns a JSON list of comments to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... The id of the organization to which the element belongs.

--- a/parts/conversations.md
+++ b/parts/conversations.md
@@ -55,7 +55,7 @@ Returns a JSON list of conversations to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... The id of the organization to which the element belongs.

--- a/parts/files.md
+++ b/parts/files.md
@@ -96,7 +96,7 @@ Returns a JSON list of files and folders to which the user has access. This inde
 
 + Parameters
 
-    + order = `id_DESC` (optional, string, `created_at_ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1295`) ... Id of the organization to which the element belongs.

--- a/parts/index.md
+++ b/parts/index.md
@@ -28,7 +28,8 @@ You can always choose in which order do you want to get your results. You can so
 - `id` → `order=id-ASC` or `order=id-DESC`
 - `created_at` → `order=created_at-ASC` or `order=created_at-DESC`
 - `updated_at` → `order=updated_at-ASC` or `order=updated_at-DESC`
-- `row_order` → `order=row_order-ASC` or `order=row_order-DESC`
+- `row_order` → `order=row_order-ASC` or `order=row_order-DESC` (only available in some endpoints)
+- `position` → `order=position-ASC` or `order=position-DESC` (only available in some endpoints)
 
 Example → Let’s ask for our conversations ordered by created_at using curl:
 

--- a/parts/index.md
+++ b/parts/index.md
@@ -25,30 +25,36 @@ The results of a GET are ordered by ascending id by default. Nevertheless, you w
 
 You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements:
 
-- id → order=id-ASC or order=id-DESC
-- created_at → order=created_at-ASC or order=created_at-DESC
-- updated_at → order=updated_at-ASC or order=updated_at-DESC
-- position → order=position-ASC or order=position-DESC
+- `id` → `order=id-ASC` or `order=id-DESC`
+- `created_at` → `order=created_at-ASC` or `order=created_at-DESC`
+- `updated_at` → `order=updated_at-ASC` or `order=updated_at-DESC`
+- `row_order` → `order=row_order-ASC` or `order=row_order-DESC`
 
 Example → Let’s ask for our conversations ordered by created_at using curl:
 
-```
+```sh
 curl -X GET -H 'Authorization: Bearer Oauth_Access_token' -d 'order=created_at-ASC' -v https://redbooth.com/api/3/conversations
+```
+
+Example → Let’s ask for our tasks ordered by the position given to them by the user using curl:
+
+```sh
+curl -X GET -H 'Authorization: Bearer Oauth_Access_token' -d 'order=row_order-ASC' -v https://redbooth.com/api/3/tasks
 ```
 
 This request will give us a JSON with all the conversations to which we have access, conversations sorted by creation date.
 
 ### Pagination
 
-By default, all list endpoints will return the first 1,000 results. More results can be retrieved by paginating using the fields: page and per_page.
+By default, all list endpoints will return the first 1,000 results. More results can be retrieved by paginating using the fields: `page` and `per_page`.
 
-- page → you choose the page that you want to get.
-- per_page → you choose how many results per page do you want to get, with a maximum of 1000.
-- page&per_page → having chosen an “x” number of results per_page, you want to see the “y” page.
+- `page` → you choose the page that you want to get.
+- `per_page` → you choose how many results per page do you want to get, with a maximum of 1000.
+- `page` & `per_page` → having chosen an "x" number of results `per_page`, you want to see the "y" `page`.
 
-Example → Let’s ask for the second page of our conversations distributed in 5-result pages using curl:
+Example → Let's ask for the second page of our conversations distributed in 5-result pages using curl:
 
-```
+```sh
 curl -X GET -H 'Authorization: Bearer Oauth_Access_token' -d 'order=id&page=2&per_page=5' -v https://redbooth.com/api/3/conversations
 ```
 
@@ -60,19 +66,19 @@ There are location filters that enable you to GET something from somewhere or to
 
 Let’s see a GET and a POST example with the conversations endpoint. This are the most used parameters in this endpoint:
 
-- organization_id → The id of the organization to which the element belongs or will belong after posting it.
-- project_id → The project’s id to which the element belongs or will belong after posting it.
-- user_id → The user’s id to which the element belongs or will belong after posting it.
+- `organization_id` → The id of the organization to which the element belongs or will belong after posting it.
+- `project_id` → The project’s id to which the element belongs or will belong after posting it.
+- `user_id` → The user’s id to which the element belongs or will belong after posting it.
 
 Example with POST:
 
-```
+```sh
 curl -X POST -H 'Content-type: application/json' -H 'Authorization: Bearer Oauth_Access_token' -d '{"name":"Example title","project_id":"x","type":"Conversation"}' -v https://redbooth.com/api/3/conversations
 ```
 
 Example with GET:
 
-```
+```sh
 curl -X GET -H 'Authorization: Bearer Oauth_Access_token' -d 'order=id&organization_id=x' -v https://redbooth.com/api/3/conversations
 ```
 

--- a/parts/memberships.md
+++ b/parts/memberships.md
@@ -53,7 +53,7 @@ Returns a JSON list of memberships in the different organizations to which the u
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... Id of the organization to which the element belongs.

--- a/parts/notes.md
+++ b/parts/notes.md
@@ -67,7 +67,7 @@ Returns a JSON list of notes to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at`, `updated_at` and `position`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... The id of the organization to which the element belongs.

--- a/parts/notifications.md
+++ b/parts/notifications.md
@@ -75,7 +75,7 @@ Returns a JSON list of notifications to be read by the user.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
 

--- a/parts/organizations.md
+++ b/parts/organizations.md
@@ -90,7 +90,7 @@ Returns a JSON list of organizaitons to which the user is related.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
 

--- a/parts/people.md
+++ b/parts/people.md
@@ -70,7 +70,7 @@ Returns a JSON list of people in the different projects to which the user has ac
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, string, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, string, `3`) ... You choose the page that you want to get.
     + organization_id (optional, string, `1283`) ... The id of the organization to which the element belongs.

--- a/parts/projects.md
+++ b/parts/projects.md
@@ -59,7 +59,7 @@ Returns a JSON list of projects to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... The id of the organization to which the element belongs.

--- a/parts/search.md
+++ b/parts/search.md
@@ -54,7 +54,7 @@ Returns a JSON with the results of your search.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at`, `updated_at` and `position`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + project_id (optional, integer, `121`) ... Id of the project to which the element belongs.

--- a/parts/subtasks.md
+++ b/parts/subtasks.md
@@ -27,6 +27,7 @@ Subtasks enable users to build checklists inside tasks. They are small subsets o
                     "name": "Review by Alexz",
                     "resolved": false,
                     "position": 3,
+                    "row_order": 3000,
                     "task_id": 13019770
                 },
                 {
@@ -37,6 +38,7 @@ Subtasks enable users to build checklists inside tasks. They are small subsets o
                     "name": "Slide design",
                     "resolved": false,
                     "position": 2,
+                    "row_order": 2000,
                     "task_id": 13019770
                 },
                 {
@@ -46,7 +48,8 @@ Subtasks enable users to build checklists inside tasks. They are small subsets o
                     "id": 479533,
                     "name": "Content",
                     "resolved": false,
-                    "position": 2,
+                    "position": 5,
+                    "row_order": 5000,
                     "task_id": 13019770
                 },
                 {
@@ -57,6 +60,7 @@ Subtasks enable users to build checklists inside tasks. They are small subsets o
                     "name": "Cover",
                     "resolved": false,
                     "position": 1,
+                    "row_order": 1000,
                     "task_id": 13019770
                 }
             ]
@@ -67,7 +71,7 @@ Returns a JSON list of subtasks that belong to a subtask with certain id.
 + Parameters
 
     + task_id (required, integer, `35456`) ... Id of the task that hosts the subtasks.
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at`, `updated_at` and `row_order`. Take into account that `position` is a calculated field thus it is not possible to order a list of tasks by using it. If you need to order the tasks by the position in the list, use `row_order` instead of `position`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
 
@@ -132,6 +136,7 @@ Posts a new subtask with a new id in the location (task_id) that you specify. Wh
                 "name":"Example subtask 2",
                 "resolved":false,
                 "position":2,
+                "row_order": 2000,
                 "task_id":13074981
             }
 
@@ -158,7 +163,7 @@ Modifies an existing subtask, purpose for which the id of the subtask that wants
     + task_id (required, integer, `35456`) ... Id of the task that will host the subtask.
     + name (required, string, `Example name`) ... The name that the subtask will have.
     + resolved = `false` (optional, string, `true`) ... This parameter determines if the subtask has been resoved or not.
-    + position (optional, integer, `1`) ... Position of the subtask in the subtask list, inside the task.
+    + position (optional, integer, `1`) ... Position of a subtask on the sub tasks list, inside the task. Note that this will modify `row_order` as a side effect.
 
 + Request
 
@@ -190,6 +195,7 @@ Modifies an existing subtask, purpose for which the id of the subtask that wants
                 "name":"Example subtask 2",
                 "resolved":true,
                 "position":2,
+                "row_order": 2000,
                 "task_id":13074981
             }
 

--- a/parts/task_list.md
+++ b/parts/task_list.md
@@ -85,7 +85,7 @@ Returns a JSON list of TaskLists to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at`, `updated_at` and `position`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... The id of the organization to which the element belongs.

--- a/parts/tasks.md
+++ b/parts/tasks.md
@@ -33,6 +33,7 @@ Tasks become the core feature of a lot organizations and they are also the most 
                     "urgent": false,
                     "user_id": 688561,
                     "position": 0,
+                    "row_order": 0,
                     "last_activity_id": 56403892,
                     "record_conversion_type": null,
                     "record_conversion_id": null,
@@ -48,7 +49,7 @@ Tasks become the core feature of a lot organizations and they are also the most 
                     "updated_by_id": null,
                     "deleted": false,
                     "due_on": null
-            },
+                },
                 {
                     "type": "Task",
                     "created_at": 1403078393,
@@ -64,6 +65,7 @@ Tasks become the core feature of a lot organizations and they are also the most 
                     "urgent": false,
                     "user_id": 688561,
                     "position": 1,
+                    "row_order": 1000,
                     "last_activity_id": 56403886,
                     "record_conversion_type": null,
                     "record_conversion_id": null,
@@ -87,7 +89,7 @@ Returns a JSON list of tasks to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: id, created_at, updated_at and position.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at`, `updated_at` and `row_order`. Take into account that `position` is a calculated field thus it is not possible to order a list of tasks by using it. If you need to order the tasks by the position in the list, use `row_order` instead of `position`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1295`) ... Id of the organization to which the element belongs.
@@ -179,6 +181,7 @@ Don't forget to "name" your task!
                     "urgent": false,
                     "user_id": 688561,
                     "position": 6,
+                    "row_order": 6500,
                     "last_activity_id": null,
                     "record_conversion_type": null,
                     "record_conversion_id": null,
@@ -237,6 +240,7 @@ Don't forget to "name" your task!
                     "urgent": false,
                     "user_id": 688561,
                     "position": 0,
+                    "row_order": 0,
                     "last_activity_id": 56403892,
                     "record_conversion_type": null,
                     "record_conversion_id": null,
@@ -295,6 +299,7 @@ Modifies an existing task, id is mandatory.
     + is_private = `false` (optional, string, `false`) ... This parameter is used to manage rights & permissions. It can be =true or =false.
     + status = `new` (optional, string, `open`) ... Tasks can have different status: new, open, hold, resolved or rejected.
     + watcher_ids (optional, array, [688561, 786268, 796268]) The ids of the users that follow the task. Note that all follower users whose id is not included in the array, except the task creator, will be removed from the task's followers.
+    + position (optional, integer, `1`) ... Numeric position of a task on the task list. Note that this will modify `row_order` as a side effect.
 
 + Request
 
@@ -312,7 +317,8 @@ Modifies an existing task, id is mandatory.
                 "assigned_user_id":"688561",
                 "watcher_ids": [
                   688561, 786268, 796268
-                ]
+                ],
+                "position": 4
             }
 
 + Response 200
@@ -340,6 +346,7 @@ Modifies an existing task, id is mandatory.
                     "urgent":false,
                     "user_id":688561,
                     "position":4,
+                    "row_order":3500,
                     "last_activity_id":56593093,
                     "record_conversion_type":null,
                     "record_conversion_id":null,


### PR DESCRIPTION
# WAT

Documentation regarding ordering for the different endpoints resources was wrong and was not taking into account things like row_order, etc. In addition to that in some endpoints it is not possible to order by position, only by id and timestamp parameters.
# Gif

![](http://i.giphy.com/RiAcnMtKucsmY.gif)
