### PR TITLE
Projects can be ordered by name

### DIFF
--- a/parts/projects.md
+++ b/parts/projects.md
@@ -59,7 +59,7 @@ Returns a JSON list of projects to which the user has access.
 
 + Parameters
 
-    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at` and `updated_at`.
+    + order = `id-DESC` (optional, string, `created_at-ASC`) ... You can always choose in which order do you want to get your results. You can sort them in ascending or descending order by the following elements: `id`, `created_at`, `updated_at` and `name`.
     + per_page = `1000`(optional, integer, `15`) ... You choose how many results per page do you want to get, with a maximum of 1000.
     + page = `1` (optional, integer, `3`) ... You choose the page that you want to get.
     + organization_id (optional, integer, `1283`) ... The id of the organization to which the element belongs.


### PR DESCRIPTION
![giphy-6](https://cloud.githubusercontent.com/assets/56472/9327104/c0d32dfa-459e-11e5-8241-5057644a76ae.gif)
# What?

Projects can also be ordered by the `name` field.
# Why?

Because API consumers want to be able to receive a sorted project list without having to implement it on their side.
# Dependencies
- https://github.com/teambox/Teambox-hosted/pull/4362
