### PR TITLE
Remove status param doc form Task index

### DIFF
--- a/parts/tasks.md
+++ b/parts/tasks.md
@@ -98,8 +98,7 @@ Returns a JSON list of tasks to which the user has access.
     + user_id (optional, integer, `12231`) ... Id of the user that created the task.
     + assigned_user_id (optional, integer, `12231`) ... Id of the user to which the task is assigned.
     + assigned (optional, string, `true`) ... The task can be assigned or unassigned, =true or =false.
-    + archived (optional, string, `true`) ... Tasks are archived once they have been completed and this parameter can be =true or =false.
-    + status (optional, string, `resolved`) ... Tasks can have different status: new, open, hold, resolved or rejected.
+    + archived (optional, string, `true`) ... Tasks are archived once they have been resolved and this parameter can be =true, =false or =all to get the tasks in both states. When the parameter is not set, by default retuns the archived=false tasks.
     + archived_project (optional, string, `false`) ... Whether the request should include tasks that belong to archived projects or not. They are included by default.
 
 


### PR DESCRIPTION
Redbooth got rid of a lot of statuses (hold, rejected...)
now the only real statuses are resolved or unresolved.
At this moment we are using archived param to get resolved an unresolved tasks,
 and by default the tasks endpoint returns the unarchived tasks.

At this moment this request GET /api/3/tasks?status=resolved
will perform this query:

```
SELECT `tasks`.* FROM `tasks` LEFT JOIN
watchers ON (
    tasks.id = watchers.watchable_id
    AND
    watchers.watchable_type
    = 'Task'
    )
AND watchers.user_id = 1
AND watchers.is_private = 1
  WHERE `tasks`.`deleted` = 0
  AND (status < 3)
AND (`tasks`.`project_id` IN (6, 7, 8, 9, 10, 11, 12, 13)
    AND `tasks`.`status` IN (3) AND (`tasks`.`is_private`
      = 0 OR
      `tasks`.`is_private` = 1 AND
      `watchers`.`user_id` = 1)) ORDER
BY id DESC LIMIT 500 OFFSET 0
```

As you can see the status < 3 and status in (3) always will return an emtpy set.

For now deprecate the status param documentation is what does makes more sense as soft deprecation.

![](http://33.media.tumblr.com/dd98aab9081b9beb1da5235e7018492e/tumblr_inline_o40ay8ASwf1raprkq_500.gif)

https://github.com/teambox/wordpress/pull/516
